### PR TITLE
Fix: verify-pia-certificate cannot be disabled

### DIFF
--- a/vpn.rsc
+++ b/vpn.rsc
@@ -417,7 +417,7 @@
         $InstallPIACertificate;
       }
     } else={
-      :set $verifyCertificateArg "no";
+      :set $verifyCertificateValue "no";
     }
 
     :local tokenUrlPath "/authv3/generateToken";


### PR DESCRIPTION
The `verifyCertificateValue` was never set to `no` as it instead modified the `verifyCertificateArg` variable.

Fixes #3 