### PR TITLE
fix: use newest serverlist (version 7)

### DIFF
--- a/vpn.rsc
+++ b/vpn.rsc
@@ -599,7 +599,7 @@
 
     :local dstPathArg [:tostr [$required $"dst-path" name="dst-path"]];
 
-    /tool/fetch url="https://serverlist.piaservers.net/vpninfo/servers/v4" mode=https dst-path=$dstPathArg
+    /tool/fetch url="https://serverlist.piaservers.net/vpninfo/servers/v7" mode=https dst-path=$dstPathArg
     $DoDelay 1s;
   }
 


### PR DESCRIPTION
The script currently uses the `https://serverlist.piaservers.net/vpninfo/servers/v4` API endpoint to retrieve the list of available VPN servers. It uses the `v4` version, which is outdated and doesn't seem to be maintained anymore, making the script non-functional when connecting to some regions. This PR upgrades to the latest version `v7` which should fix issues connecting to various regions such as `de_berlin`.